### PR TITLE
added 'Bind Selections' config option to toggle fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/classes/
+/target/
+.inputrc
+.classpath
+.project

--- a/src/main/java/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition.java
+++ b/src/main/java/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition.java
@@ -153,7 +153,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 
 	private String value;
 	
-	private boolean bindedSelect;
+	private boolean bindSelect;
 		
 	private String propertyFile;
 
@@ -180,7 +180,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 	@DataBoundConstructor
 	public ExtendedChoiceParameterDefinition(String name, String type, String value, String propertyFile, String propertyKey, String defaultValue,
 			String defaultPropertyFile, String defaultPropertyKey, boolean quoteValue, int visibleItemCount, String description,
-			String multiSelectDelimiter, String bindFieldName, boolean svnPath, String svnUrl, String svnUserName, String svnPassword, String projectName, boolean bindedSelect, boolean roleBasedFilter) {
+			String multiSelectDelimiter, String bindFieldName, boolean svnPath, String svnUrl, String svnUserName, String svnPassword, String projectName, boolean bindSelect, boolean roleBasedFilter) {
 		super(name, description);
 		this.type = type;
 
@@ -195,7 +195,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 		this.svnPath = svnPath;
 		this.roleBasedFilter = roleBasedFilter;
 		this.bindFieldName = bindFieldName;
-		this.bindedSelect = bindedSelect;		
+		this.bindSelect = bindSelect;		
 		if(visibleItemCount == 0) {
 			visibleItemCount = 5;
 		}
@@ -391,7 +391,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 				
 				if (this.type.equals("PT_SINGLE_SELECT"))
 				{
-					result+="<select name=\"value\" id=\"selectlist\" class=\"" + this.bindedSelect + "\">"; // class=\"true\"	
+					result+="<select name=\"value\" id=\"selectlist\" class=\"" + this.bindSelect + "\">"; // class=\"true\"	
 					for (int i = 0; i < list_arr.length; ++i)
 					{
 				
@@ -855,12 +855,12 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 		this.quoteValue = quoteValue;
 	}
 	
-	public boolean isBindedSelect() {
-		return bindedSelect;
+	public boolean isBindSelect() {
+		return bindSelect;
 	}
 
-	public void setBindedSelect(boolean bindedSelect) {
-		this.bindedSelect = bindedSelect;
+	public void setBindSelect(boolean bindSelect) {
+		this.bindSelect = bindSelect;
 	}
 
 	public boolean isSvnPath() {

--- a/src/main/java/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition.java
+++ b/src/main/java/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition.java
@@ -152,6 +152,8 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 	private String type;
 
 	private String value;
+	
+	private boolean bindedSelect;
 		
 	private String propertyFile;
 
@@ -178,7 +180,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 	@DataBoundConstructor
 	public ExtendedChoiceParameterDefinition(String name, String type, String value, String propertyFile, String propertyKey, String defaultValue,
 			String defaultPropertyFile, String defaultPropertyKey, boolean quoteValue, int visibleItemCount, String description,
-			String multiSelectDelimiter, String bindFieldName, boolean svnPath, String svnUrl, String svnUserName, String svnPassword, String projectName, boolean roleBasedFilter) {
+			String multiSelectDelimiter, String bindFieldName, boolean svnPath, String svnUrl, String svnUserName, String svnPassword, String projectName, boolean bindedSelect, boolean roleBasedFilter) {
 		super(name, description);
 		this.type = type;
 
@@ -193,6 +195,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 		this.svnPath = svnPath;
 		this.roleBasedFilter = roleBasedFilter;
 		this.bindFieldName = bindFieldName;
+		this.bindedSelect = bindedSelect;		
 		if(visibleItemCount == 0) {
 			visibleItemCount = 5;
 		}
@@ -388,7 +391,7 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 				
 				if (this.type.equals("PT_SINGLE_SELECT"))
 				{
-					result+="<select name=\"value\">";
+					result+="<select name=\"value\" id=\"selectlist\" class=\"" + this.bindedSelect + "\">"; // class=\"true\"	
 					for (int i = 0; i < list_arr.length; ++i)
 					{
 				
@@ -850,6 +853,14 @@ public class ExtendedChoiceParameterDefinition extends ParameterDefinition {
 
 	public void setQuoteValue(boolean quoteValue) {
 		this.quoteValue = quoteValue;
+	}
+	
+	public boolean isBindedSelect() {
+		return bindedSelect;
+	}
+
+	public void setBindedSelect(boolean bindedSelect) {
+		this.bindedSelect = bindedSelect;
 	}
 
 	public boolean isSvnPath() {

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/config.jelly
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/config.jelly
@@ -106,8 +106,8 @@
     <f:textbox value="${bindFieldName}"/>
   </f:entry>
   
-  <f:entry title="Binded Selections" field="bindedSelect">
-	<f:checkbox checked="${instance.bindedSelect}"/>
+  <f:entry title="Bind Selections" field="bindSelect">
+	<f:checkbox checked="${instance.bindSelect}"/>
   </f:entry>
   
   <f:entry title="Role Based Filter" field="roleBasedFilter">

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/config.jelly
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/config.jelly
@@ -106,6 +106,10 @@
     <f:textbox value="${bindFieldName}"/>
   </f:entry>
   
+  <f:entry title="Binded Selections" field="bindedSelect">
+	<f:checkbox checked="${instance.bindedSelect}"/>
+  </f:entry>
+  
   <f:entry title="Role Based Filter" field="roleBasedFilter">
     <f:checkbox checked="${instance.roleBasedFilter}"/>
   </f:entry>

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/help-bindedSelect.html
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/help-bindedSelect.html
@@ -1,0 +1,11 @@
+<!--
+ Copyright (c) 2014 Isac, Len
+ See the file license.txt for copying permission. 
+-->
+
+
+<div>
+    <p>Check this option to bind <i>Single Select</i> options with Build screen fields(based off their names).</p>
+    <p>When an option is selected, the corresponding field will show, and the rest of the fields(within the Single Select list) will be hidden</p>
+    
+</div>

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/help-bindedSelect.html
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/help-bindedSelect.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2014 Isac, Len
+ Copyright (c) 2014 Len Isac
  See the file license.txt for copying permission. 
 -->
 

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/index.jelly
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/index.jelly
@@ -9,10 +9,10 @@
   xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
   xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
 
-	<!-- Check if 'Binded Selections' is checked or not, and set it's id --> 
+	<!-- Check if 'Bind Selections' is checked or not, and set it's id --> 
 	<j:choose>
-		<j:when test="${it.bindedSelect eq true}">
-			<j:set var="selectlist_id" value="selectlist_binded"/>
+		<j:when test="${it.bindSelect eq true}">
+			<j:set var="selectlist_id" value="selectlist_bind"/>
 		</j:when>
 		<j:otherwise>
 			<j:set var="selectlist_id" value="${it.name}"/>

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/index.jelly
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/index.jelly
@@ -9,7 +9,7 @@
   xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
   xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
 
-	// Check if 'Binded Selections' is checked or not, and set it's id 
+	<!-- Check if 'Binded Selections' is checked or not, and set it's id --> 
 	<j:choose>
 		<j:when test="${it.bindedSelect eq true}">
 			<j:set var="selectlist_id" value="selectlist_binded"/>

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/index.jelly
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/index.jelly
@@ -9,6 +9,7 @@
   xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
   xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
 
+	// Check if 'Binded Selections' is checked or not, and set it's id 
 	<j:choose>
 		<j:when test="${it.bindedSelect eq true}">
 			<j:set var="selectlist_id" value="selectlist_binded"/>
@@ -50,19 +51,22 @@
 		var file_tmp_path=home_path + str + ".txt";
 		var file_name=file_tmp_path;
 		var file_key="${it.propertyKey}";
-		response_data=""
-		document.getElementById("spinnerImg_${it.name}").style.display = "";
+		response_data="";
+		
+		if (!bindfieldname) { document.getElementById("spinnerImg_${it.name}").style.display = "none"; } // don't show spinner image if 'Bind with Field' is not being used		
+		else { document.getElementById("spinnerImg_${it.name}").style.display = "";	}
+		
 		element=get_parent(bindfieldname);
 		
 		var parent_element=element.parentNode;
 		parent_element.childNodes[ parent_element.childNodes.length - 1 ].disabled = true;
 		
 		foo.computeValue(file_name,file_key,src_name, function(t) {
+			document.getElementById("spinnerImg_${it.name}").style.display = "";
 			response_data = t.responseObject();
 			parent_element.removeChild(parent_element.childNodes[ parent_element.childNodes.length - 1 ]);
 			parent_element.innerHTML = parent_element.innerHTML + response_data;
 			document.getElementById("spinnerImg_${it.name}").style.display = "none";
-					
 		});
 		}
 </script>

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/index.jelly
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/index.jelly
@@ -8,11 +8,21 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
   xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
   xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+
+	<j:choose>
+		<j:when test="${it.bindedSelect eq true}">
+			<j:set var="selectlist_id" value="selectlist_binded"/>
+		</j:when>
+		<j:otherwise>
+			<j:set var="selectlist_id" value="${it.name}"/>
+		</j:otherwise>
+	</j:choose>  
+  
   <f:entry title="${it.name}" description="${it.description}">
     <div name="parameter" id="parameter" description="${it.description}">
       <j:set var="type" value="${it.type}"/>
       <input type="hidden" name="name" value="${it.name}" />
-        <select name="value" id="${it.name}" onChange="get_data_${it.name}(this.value)">
+        <select name="value" id="${selectlist_id}" onChange="get_data_${it.name}(this.value)">
           <st:include page="selectContent.jelly"/>
         </select>
 		<img src="${rootURL}/images/spinner.gif" id="spinnerImg_${it.name}" style="display:none;" />

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/selectContent.jelly
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/selectContent.jelly
@@ -8,8 +8,8 @@
   xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
   xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   
-	<!--<script type="text/javascript" src="http://code.jquery.com/jquery-latest.min.js"></script>-->
-	<st:adjunct includes="org.kohsuke.stapler.jquery"/>
+	<!-- <script type="text/javascript" src="http://code.jquery.com/jquery-latest.min.js"></script> -->	
+	<st:adjunct includes="org.kohsuke.stapler.jquery"/> <!-- requires installation of 'jQuery' plugin on Jenkins -->
 	<script type="text/javascript">
 	
 		jQuery(document).ready(function ($) 

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/selectContent.jelly
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/selectContent.jelly
@@ -14,15 +14,15 @@
 	
 		jQuery(document).ready(function ($) 
 		{
-			// Binded Select option for Single Select
-			jQuery( '#selectlist_binded' ).change( function()
+			// Bind Select option for Single Select
+			jQuery( '#selectlist_bind' ).change( function()
 			{
 				var tdbodyToShow = jQuery(this).val();
 					
 				var selectlistOptions = [];
 					
 				// Store selectlist options in array
-				jQuery('#selectlist_binded option').each(function()
+				jQuery('#selectlist_bind option').each(function()
 				{
 					selectlistOptions.push( this.value );
 				});

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/selectContent.jelly
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/selectContent.jelly
@@ -7,6 +7,37 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
   xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
   xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+  
+	<!--<script type="text/javascript" src="http://code.jquery.com/jquery-latest.min.js"></script>-->
+	<st:adjunct includes="org.kohsuke.stapler.jquery"/>
+	<script type="text/javascript">
+	
+		jQuery(document).ready(function ($) 
+		{
+			// Binded Select option for Single Select
+			jQuery( '#selectlist_binded' ).change( function()
+			{
+				var tdbodyToShow = jQuery(this).val();
+					
+				var selectlistOptions = [];
+					
+				// Store selectlist options
+				jQuery('#selectlist_binded option').each(function()
+				{
+					selectlistOptions.push( this.value );
+				});
+			       
+		        // Show only selected choice, hide the rest
+				for (var i = 0; i &lt; selectlistOptions.length; i++) 
+		        {
+			       	selectlistOptions[i] == tdbodyToShow ? jQuery("td.setting-name:contains('"+ selectlistOptions[i] + "')").parent().parent().show()
+			       			: jQuery("td.setting-name:contains('"+ selectlistOptions[i] + "')").parent().parent().hide();			        	
+			       }
+			}).change(); // call change function on page load
+		});
+		
+	</script>  
+  
   <j:set var="defaultValueMap" value="${it.defaultValueMap}"/>
   <j:set var="effectiveValue" value="${it.effectiveValue}"/>
   <j:forEach var="value" items="${effectiveValue}">

--- a/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/selectContent.jelly
+++ b/src/main/resources/com/moded/extendedchoiceparameter/ExtendedChoiceParameterDefinition/selectContent.jelly
@@ -21,18 +21,28 @@
 					
 				var selectlistOptions = [];
 					
-				// Store selectlist options
+				// Store selectlist options in array
 				jQuery('#selectlist_binded option').each(function()
 				{
 					selectlistOptions.push( this.value );
 				});
-			       
+				
 		        // Show only selected choice, hide the rest
 				for (var i = 0; i &lt; selectlistOptions.length; i++) 
-		        {
-			       	selectlistOptions[i] == tdbodyToShow ? jQuery("td.setting-name:contains('"+ selectlistOptions[i] + "')").parent().parent().show()
-			       			: jQuery("td.setting-name:contains('"+ selectlistOptions[i] + "')").parent().parent().hide();			        	
-			       }
+				{
+					if ( selectlistOptions[i] === tdbodyToShow ) 
+					{
+						$("td.setting-name").filter(function() {
+							  return $(this).text() === selectlistOptions[i];
+						}).parent().parent().show();
+					}
+					else
+					{
+						$("td.setting-name").filter(function() {
+							  return $(this).text() === selectlistOptions[i];
+						}).parent().parent().hide();
+					}
+			    }
 			}).change(); // call change function on page load
 		});
 		


### PR DESCRIPTION
This feature binds (Moded Extended Choice Parameter) Single Select options with build page fields.  When an option is selected, the corresponding field will show and the rest of the fields (in the Single Select list) will be hidden.

dependencies: [jQuery](https://wiki.jenkins-ci.org/display/JENKINS/jQuery+Plugin) plugin

Example:

![config](https://cloud.githubusercontent.com/assets/5377677/7256075/27ca5dd0-e81b-11e4-917b-9daf908928d9.png)

<i>note: This option will not conflict with the 'Bind with Field' option.  They can both be used at the same time.</i>

<b>Without</b> <i>'Bind Select'</i> config option checked - all fields would be visible:
![withoutbind](https://cloud.githubusercontent.com/assets/5377677/7256440/2f5d5014-e81d-11e4-916a-e081c2d95822.png)

<b>With</b> <i>'Bind Select'</i> config option checked - (first Value is set to <i>Select</i> for all bound fields to be hidden at first):
![noneselected](https://cloud.githubusercontent.com/assets/5377677/7256126/70744078-e81b-11e4-8410-ccf10998b366.png)

<b>Extended Choice Paramter</b> (Multi-Level Multi Select) field selected:
![extendedselected](https://cloud.githubusercontent.com/assets/5377677/7256370/b2b5d4a0-e81c-11e4-8081-5e58f6d83f42.png)

<b>String</b> field selected:
![stringparam](https://cloud.githubusercontent.com/assets/5377677/7256365/a9e01d90-e81c-11e4-9d09-7c7d866c0705.png)

<b>Text</b> field selected:
![textparam](https://cloud.githubusercontent.com/assets/5377677/7256360/9ebac122-e81c-11e4-94e6-97f08d3b56f9.png)
